### PR TITLE
Add AI declaration, simplify typst file structure

### DIFF
--- a/report/typst-template/appendix.typ
+++ b/report/typst-template/appendix.typ
@@ -1,0 +1,6 @@
+== Use of AI tools
+
+// Write about the usage of AI tools if any - specify details. E.g.:
+
+// Parts of the code associated with this Master thesis were produced with the assistance of AI tools. Specifically, in <context>, <tool> was used, for the purpose of <purpose> in sections of the file `<file>`. 
+// No AI tools were employed for the production of the written thesis or that of the materials used for the associated presentation.

--- a/report/typst-template/declaration.typ
+++ b/report/typst-template/declaration.typ
@@ -1,0 +1,43 @@
+// Choose the version in either English or German, with the appropriate middle paragraph depending on whether or not you used AI tools.
+
+
+= Declaration of authorship
+
+I hereby declare that the work presented in this thesis is entirely my own. I did not use any sources or aids other than those specified (including AI-based applications or tools). All literal or paraphrased quotations and citations are identified and referenced. I assure that I have not used any aids whose use has been explicitly excluded by the examiner.
+
+------------- CHOOSE ONE: // delete this line in the final thesis after selecting the appropriate version
+
+// Without use of AI tools:
+By submitting this work, I assume responsibility for the entire product submitted. I have checked the accuracy of the statements and content to the best of my knowledge.
+
+// Using AI tools
+In the appendix “Use of AI Tools”, I have documented the AI tools I have used. By submitting this work, I assume responsibility for the entire product submitted. I am therefore also responsible for any AI-generated content that I have included in my work. I have checked the accuracy of the (AI-generated) statements and content to the best of my knowledge.
+
+------------- // delete this line in the final thesis after selecting the appropriate version
+
+Neither this work nor any substantial parts of it have been the subject of any other examination procedure to date. I have not published this work either in part or in full to date. The electronic copy corresponds to all hard copies submitted.
+
+Date and Signature:
+
+
+
+
+= Eigenständigkeitserklärung
+
+Hiermit erkläre ich, dass ich die vorliegende Arbeit selbstständig verfasst und keine anderen als die angegebenen Quellen und Hilfsmittel (dazu zählen auch KI-basierte Anwendungen oder Werkzeuge) benutzt habe. Sämtliche wörtlichen oder sinngemäßen Übernahmen und Zitate sind kenntlich gemacht und nachgewiesen. Ich versichere, dass ich keine Hilfsmittel verwendet habe, deren Nutzung die Prüferin oder der Prüfer explizit ausgeschlossen hat.
+
+
+------------- CHOOSE ONE: // delete this line in the final thesis after selecting the appropriate version
+
+// Ohne Nutzung von KI-Tools:
+Mit Abgabe der vorliegenden Arbeit übernehme ich die Verantwortung für das eingereichte Gesamtprodukt. Die Richtigkeit übernommener Aussagen und Inhalte habe ich nach bestem Wissen und Gewissen geprüft. 
+
+// Mit Nutzung von KI-Tools:
+Im Anhang „Nutzung KI-Tools“ habe ich die von mir verwendeten KI-Tools dokumentiert. Zudem habe ich im Anhang „KI-Outputs“ sämtliche KI-generierten Outputs einzeln aufgeführt, die relevant für die Aufgabe waren. Mit Abgabe der vorliegenden Arbeit übernehme ich die Verantwortung für das eingereichte Gesamtprodukt. Ich verantworte damit auch jegliche KI-generierten Inhalte, die ich in meine Arbeit übernommen habe. Die Richtigkeit übernommener (KI-generierter) Aussagen und Inhalte habe ich nach bestem Wissen und Gewissen geprüft.
+
+------------- // delete this line in the final thesis after selecting the appropriate version
+
+
+Weder diese Arbeit noch wesentliche Teile daraus waren bisher Gegenstand eines anderen Prüfungsverfahrens. Ich habe diese Arbeit bisher weder teilweise noch vollständig veröffentlicht. Das elektronische Exemplar stimmt mit allen eingereichten Exemplaren überein.
+
+Datum, Unterschrift des/der Studierenden:

--- a/report/typst-template/main.typ
+++ b/report/typst-template/main.typ
@@ -1,3 +1,0 @@
-// To display the proposal or the thesis, uncomment the respective line and comment out the other.
-#include "proposal.typ"
-// #include "thesis.typ"

--- a/report/typst-template/template/template.typ
+++ b/report/typst-template/template/template.typ
@@ -365,6 +365,8 @@
   listing-index: true,
   // List of abbreviations
   abbreviations: none,
+  // Declaration
+  declaration: none,
   // The content of your work.
   body,
 ) = {

--- a/report/typst-template/thesis.typ
+++ b/report/typst-template/thesis.typ
@@ -10,10 +10,15 @@
 #let acknowledgements = [#lorem(50)]
 
 
+// Declaration regarding own work / AI use: adapted from the guidelines of the Computer Science Department, Faculty 5, Uni-Stuttgart 
+#let declaration = [
+  #include "declaration.typ"
+]
+
 // if you have appendices, add them here
 #let appendix = [
   = Appendices
-  //#include "./chapters/appendix.typ"
+  #include "appendix.typ"
 ]
 
 // Put your abbreviations/acronyms here.
@@ -71,6 +76,7 @@
   abbreviations: abbreviations,
   date: datetime(year: 2025, month: 6, day: 1),
   bibliography: bibliography("refs.bib", title: "Bibliography", style: "american-psychological-association"),
+  declaration: declaration
 )
 
 // Code blocks


### PR DESCRIPTION
Changes:
- Added a declaration on AI use - this becomes an appendix in the thesis.
- Removed main.typ since it's simpler to just render the thesis/proposal typ files as required. 